### PR TITLE
Added: CMake-based build-system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,4 +7,4 @@ include_directories (${C2SDK})
 
 add_subdirectory (src)
 add_subdirectory (demo)
-#add_subdirectory (test)
+add_subdirectory (test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required (VERSION 3.3.2)
+project (easy-erg)
+
+set (C2SDK "D:/Concept2/Software Development Kit" CACHE PATH "Sets the directory where the C2 SDK headers reside")
+FILE(GLOB C2SDK_LIBRARIES ${C2SDK}/*.lib)
+include_directories (${C2SDK})
+
+add_subdirectory (src)
+add_subdirectory (demo)
+#add_subdirectory (test)

--- a/demo/CMakeLists.txt
+++ b/demo/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../src/)
+
+add_executable(demo demo.cpp)
+add_executable(demoDiscoverErgs demoDiscoverErgs.cpp)
+add_executable(demoIntervals demoIntervals.cpp)
+add_executable(demoState demoState.cpp)
+
+target_link_libraries(demo easy-erg)
+target_link_libraries(demoDiscoverErgs easy-erg)
+target_link_libraries(demoIntervals easy-erg)
+target_link_libraries(demoState easy-erg)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,7 @@
+
+FILE (GLOB SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+FILE (GLOB HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
+
+add_library (easy-erg ${SOURCES} ${HEADERS})
+
+target_link_libraries(easy-erg ${C2SDK_LIBRARIES})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,22 @@
+
+enable_testing()
+
+FILE (GLOB HEADERS ${CMAKE_CURRENT_SOURCE_DIR}/*.h)
+
+set(GMOCK_LIBRARY "E:/Github/gmock-1.7.0/msvc/2010/Release/gmock.lib" CACHE FILEPATH "Path to the (static) gmock library")
+set(GMOCK_INCLUDE_DIR "E:/Github/gmock-1.7.0/include" CACHE PATH "Path to the gmock includes")
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../src/)    #easy-erg
+include_directories(${GMOCK_INCLUDE_DIR})                   #gmock
+include_directories(${GMOCK_INCLUDE_DIR}/../gtest/include)  #gtest
+
+add_executable(test_discover_ergs ${HEADERS} test_discover_ergs.cpp )
+add_executable(test_running_average ${HEADERS} test_running_average.cpp )
+
+target_link_libraries(test_discover_ergs    easy-erg
+                                            ${GMOCK_LIBRARY})
+target_link_libraries(test_running_average  easy-erg
+                                            ${GMOCK_LIBRARY})
+                                            
+add_test(c2tests test_discover_ergs)
+add_test(c2tests test_running_average)


### PR DESCRIPTION
CMake-based build-system to allow building with Visual Studio (other build-platforms should be supported too). It's not needed anymore to have cygwin, dlltool and pexports installed to build and use this software on a windows environment. Take note that tests are currently missing
